### PR TITLE
README - Reorganization; add Zenodo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
+# Automated Water Supply Model (AWSM)
+Execution of the iSnobal snow mass and energy model along with the 
+[Spatial Modeling for Resources Framework](https://github.com/iSnobal/smrf). iSnobal
+itself is called via [pysnobal](https://github.com/iSnobal/pysnobal) and AWSM
+wraps the interface of both packages into a central execution framework.
 
-# Fork of the Automated Water Supply Model (AWSM)
-
-This is a fork of the [USDA-ARS-NWRC AWSM](https://github.com/USDA-ARS-NWRC/awsm) repo
-to continue the development of the framework.
+# Installation
+Setting up the model uses the `conda` environment management software.
+A setup follows the steps described in the
+[iSnobal instructions](https://github.com/iSnobal/model_setup)
 
 # Usage
 The installation of this package provides a command line interface to run the model.
@@ -47,15 +52,21 @@ optional arguments:
                         Set the medium mass threshold. Default: 25
 ```
 
-# Installation
+# Citation
+Each release of AWSM triggers a DOI via Zenodo and 
+[all versions can be found here](https://zenodo.org/search?q=parent.id%3A6543918&f=allversions%3Atrue&l=list&p=1&s=10&sort=version)
 
-Setting up the model uses the `conda` environment management software.
-A setup follows the steps described in the
-[isnoda instructions](https://github.com/UofU-Cryosphere/isnoda/tree/master/conda)
+DOI for all versions is: https://doi.org/10.5281/zenodo.6543918
+which always points to the latest release.
 
 # History
+## Fork of the Automated Water Supply Model (AWSM)
+
+This is a fork of the [USDA-ARS-NWRC AWSM](https://github.com/USDA-ARS-NWRC/awsm) repo
+to continue the development of the framework.
 This repo was used in the following publications
 
+## Publications
 * Meyer, J., Horel, J., Kormos, P., Hedrick, A., Trujillo, E., and Skiles, S. M.: Operational water forecast ability of the HRRR-iSnobal combination: an evaluation to adapt into production environments, Geosci. Model Dev., 16, 233–250, https://doi.org/10.5194/gmd-16-233-2023, 2023.
   Zenodo [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7452230.svg)](https://doi.org/10.5281/zenodo.7452230)
 


### PR DESCRIPTION
Reorganize the README putting installation and execution at the top. Adds reference to Zenodo and how to find a DOI for publication.