### PR TITLE
Release - 20251208 - Includes AWSM, SMRF, Pysnobal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9"
 ]
 dependencies = [
-    'smrf @ git+https://github.com/UofU-Cryosphere/smrf.git@20250722',
-    'pysnobal @ git+https://github.com/iSnobal/pysnobal.git@20251001',
+    'smrf @ git+https://github.com/UofU-Cryosphere/smrf.git@20251208',
+    'pysnobal @ git+https://github.com/iSnobal/pysnobal.git@20251208',
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/UofU-Cryosphere/awsm"
+Homepage = "https://github.com/iSnobal/awsm"
 
 [project.scripts]
 awsm = "awsm.cli:main"


### PR DESCRIPTION
Make Toposplit part of the installed version via conda.
Release tag to follow after this.